### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Manual setup:
 - Download *Visual Genome* metadata: `sh custom_files/download_VG.sh`
 - Download pre-trained model: `sh custom_files/download_pretrained.sh`
 - Download NVIDIA Docker image: `docker pull nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04`
-- Build Docker image: `docker build -t au/sgb:10.1-cudnn7-devel-ubuntu18.04 ./docker --build_arg FORCE_CUDA=1`
+- Build Docker image: `docker build -t au/sgb:10.1-cudnn7-devel-ubuntu18.04 ./docker --build-arg FORCE_CUDA=1`
 
 Activation of the environments:
 - Run Docker image: `docker run -it -v $PWD:/sgb --gpus all au/sgb:10.1-cudnn7-devel-ubuntu18.04`
@@ -38,7 +38,7 @@ Manual setup:
 - Download *Visual Genome* metadata: `sh custom_files/download_VG.sh`
 - Download pre-trained model: `sh custom_files/download_pretrained.sh`
 - Download NVIDIA Docker image: `docker pull nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04`
-- Build Docker image: `docker build -t au/sgb:10.1-cudnn7-devel-ubuntu18.04 ./docker --build_arg FORCE_CUDA=0`
+- Build Docker image: `docker build -t au/sgb:10.1-cudnn7-devel-ubuntu18.04 ./docker --build-arg FORCE_CUDA=0`
 
 Activation of the environments:
 - Run Docker image: `docker run -it -v $PWD:/sgb au/sgb:10.1-cudnn7-devel-ubuntu18.04`

--- a/custom_files/download_pretrained.sh
+++ b/custom_files/download_pretrained.sh
@@ -8,7 +8,7 @@ mkdir -p checkpoints
 
 # Causal-TDE: Unbiased Neural Motifs
 cd checkpoints
-mkdir causal_tde
+mkdir -p causal_tde
 cd causal_tde
 #wget https://penzhanwu2.blob.core.windows.net/sgg/sgg_benchmark/sgg_model_zoo/visualgenome/nm_usefpTrue_lr0.015_bsz8_objctx0_edgectx2_shareboxFalse/model_final.pth -O "model_final.pth"
 wget https://penzhanwu2.blob.core.windows.net/sgg/sgg_benchmark/sgg_model_zoo/visualgenome/nm_usefpFalse_lr0.015_bsz8_objctx0_edgectx2_shareboxFalse/model_0035000.pth -O "model_0035000.pth"

--- a/installation_steps.sh
+++ b/installation_steps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-ForceCuda = ${1:-1}
+ForceCuda=${1:-1}
 
 # Download Visual Genome metadata
 sh custom_files/download_VG.sh
@@ -11,4 +11,4 @@ sh custom_files/download_pretrained.sh
 # Download NVIDIA Docker image
 docker pull nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 # Build Docker image
-docker build -t au/sgb:10.1-cudnn7-devel-ubuntu18.04 ./docker --build_arg FORCE_CUDA=${ForceCuda}
+docker build -t au/sgb:10.1-cudnn7-devel-ubuntu18.04 ./docker --build-arg FORCE_CUDA=${ForceCuda}


### PR DESCRIPTION
The "-p" in `custom_files/download_pretrained.sh` has been added because putting `set -e` at the beginning of the document made the execution of the file stop at the line 11. This is because checkpoints/causal_tde is already present when one clones the repository, so when downloading the model, the error `causal_tde already exists` appears, thus stopping the execution. Adding "-p", the directory created overwrites the existing one and the execution continues.